### PR TITLE
Fix reading message data; remove debug prints

### DIFF
--- a/lib/Net/ZMQ/Message.pm
+++ b/lib/Net/ZMQ/Message.pm
@@ -58,7 +58,7 @@ my sub zmq_msg_move(Net::ZMQ::Message --> int) is native('libzmq') { * }
 # ZMQ_EXPORT int zmq_msg_copy (zmq_msg_t *dest, zmq_msg_t *src);
 my sub zmq_msg_copy(Net::ZMQ::Message --> int) is native('libzmq') { * }
 # ZMQ_EXPORT void *zmq_msg_data (zmq_msg_t *msg);
-my sub zmq_msg_data(Net::ZMQ::Message --> Str) is native('libzmq') { * }
+my sub zmq_msg_data(Net::ZMQ::Message --> CArray[int8]) is native('libzmq') { * }
 # ZMQ_EXPORT size_t zmq_msg_size (zmq_msg_t *msg);
 my sub zmq_msg_size(Net::ZMQ::Message --> int) is native('libzmq') { * }
 
@@ -80,7 +80,12 @@ multi submethod BUILD(:$message!) {
 # TODO: We'll probably want various methods of accessing the data once we have
 # proper blob handling.
 method data() {
-    return zmq_msg_data(self);
+    my $buf = buf8.new;
+    my $zmq_data = zmq_msg_data(self);
+    for 0..^zmq_msg_size(self) {
+        $buf ~= buf8.new($zmq_data[$_]);
+    }
+    return $buf.decode;
 }
 
 method size() {

--- a/lib/Net/ZMQ/Socket.pm
+++ b/lib/Net/ZMQ/Socket.pm
@@ -106,14 +106,10 @@ method connect(Str $address) {
 
 # TODO: There's probably a more Perlish way to handle the flags.
 multi method send(Str $message, $flags = 0) {
-    say "going to send";
     my $buf = $message.encode("utf8");
     my $carr = CArray[int8].new;
-    for $buf.list.kv -> $idx, $val { $carr[$idx] = $val; say "$idx $val" }
-    say $buf.perl;
-    say $carr.perl;
+    for $buf.list.kv -> $idx, $val { $carr[$idx] = $val; }
     my $ret = zmq_send(self, $carr, $buf.elems, $flags);
-    say "sent";
     zmq_die if $ret == -1;
     return $ret;
 }
@@ -139,19 +135,19 @@ method getopt($opt) {
     given %opttypes{$opt} {
         when int {
             $val = CArray[int].new;
-            $val[0] = int;
+            $val[0] = 0;
             $optlen[0] = 4;
             $ret = zmq_getsockopt_int(self, $opt, $val, $optlen);
         }
         when int32 {
             $val = CArray[int32].new;
-            $val[0] = int32;
+            $val[0] = 0;
             $optlen[0] = 4;
             $ret = zmq_getsockopt_int32(self, $opt, $val, $optlen);
         }
         when int64 {
             $val = CArray[int64].new;
-            $val[0] = int64;
+            $val[0] = 0;
             $optlen[0] = 8;
             $ret = zmq_getsockopt_int64(self, $opt, $val, $optlen);
         }


### PR DESCRIPTION
We can't treat the data from libzmq as a C string, as it is not
guaranteed to have a null byte at the end. Instead, we need to read
zmq_msg_size() bytes into a buffer and decode that.

This fixes the existing tests.
