### PR TITLE
Add unit declarator to module and class declarations

### DIFF
--- a/lib/Net/ZMQ.pm
+++ b/lib/Net/ZMQ.pm
@@ -1,4 +1,4 @@
-module Net::ZMQ;
+unit module Net::ZMQ;
 
 use Net::ZMQ::Constants;
 use Net::ZMQ::Context;

--- a/lib/Net/ZMQ/Constants.pm
+++ b/lib/Net/ZMQ/Constants.pm
@@ -1,5 +1,5 @@
 # All the various constants that are #defined in zmq.h
-module Net::ZMQ::Constants;
+unit module Net::ZMQ::Constants;
 
 # Message constants:
 our constant ZMQ_MSG_MORE   is export(:DEFAULT, :message) = 1;

--- a/lib/Net/ZMQ/Context.pm
+++ b/lib/Net/ZMQ/Context.pm
@@ -1,5 +1,5 @@
 use NativeCall;
-class Net::ZMQ::Context is repr('CPointer');
+unit class Net::ZMQ::Context is repr('CPointer');
 
 use Net::ZMQ::Util;
 

--- a/lib/Net/ZMQ/Message.pm
+++ b/lib/Net/ZMQ/Message.pm
@@ -1,5 +1,5 @@
 use NativeCall;
-class Net::ZMQ::Message is repr('CStruct');
+unit class Net::ZMQ::Message is repr('CStruct');
 
 use Net::ZMQ::Util;
 

--- a/lib/Net/ZMQ/Poll.pm
+++ b/lib/Net/ZMQ/Poll.pm
@@ -2,7 +2,7 @@ use Net::ZMQ::Pollitem;
 
 use NativeCall;
 
-module Net::ZMQ::Poll;
+unit module Net::ZMQ::Poll;
 
 # ZMQ_EXPORT int zmq_poll (zmq_pollitem_t *items, int nitems, long timeout);
 my sub zmq_poll(CArray[Net::ZMQ::Pollitem], int, Int --> int) is native('libzmq') { * }

--- a/lib/Net/ZMQ/Pollitem.pm
+++ b/lib/Net/ZMQ/Pollitem.pm
@@ -1,5 +1,5 @@
 use NativeCall;
-class Net::ZMQ::Pollitem is repr('CStruct');
+unit class Net::ZMQ::Pollitem is repr('CStruct');
 
 use Net::ZMQ::Constants;
 use Net::ZMQ::Socket;

--- a/lib/Net/ZMQ/Socket.pm
+++ b/lib/Net/ZMQ/Socket.pm
@@ -1,5 +1,5 @@
 use NativeCall;
-class Net::ZMQ::Socket is repr('CPointer');
+unit class Net::ZMQ::Socket is repr('CPointer');
 
 use Net::ZMQ::Constants;
 use Net::ZMQ::Context;

--- a/lib/Net/ZMQ/Util.pm
+++ b/lib/Net/ZMQ/Util.pm
@@ -1,4 +1,4 @@
-module Net::ZMQ::Util;
+unit module Net::ZMQ::Util;
 
 use NativeCall;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.