### PR TITLE
Fix the wrong sized Message struct.

### DIFF
--- a/lib/Net/ZMQ/Message.pm
+++ b/lib/Net/ZMQ/Message.pm
@@ -3,44 +3,18 @@ unit class Net::ZMQ::Message is repr('CStruct');
 
 use Net::ZMQ::Util;
 
-has OpaquePointer $!content;
-has int8 $!flags;
-has int8 $!vsm_size;
-
 # XXX Hack, hack, hack!
 # NativeCall has no way of dealing with flattened arrays yet, so for the time
-# being, we just hack around it by embedding 30 byte members instead of a
-# 30-byte flattened array.
-has int8 $!vsm_data0;
-has int8 $!vsm_data1;
-has int8 $!vsm_data2;
-has int8 $!vsm_data3;
-has int8 $!vsm_data4;
-has int8 $!vsm_data5;
-has int8 $!vsm_data6;
-has int8 $!vsm_data7;
-has int8 $!vsm_data8;
-has int8 $!vsm_data9;
-has int8 $!vsm_data10;
-has int8 $!vsm_data11;
-has int8 $!vsm_data12;
-has int8 $!vsm_data13;
-has int8 $!vsm_data14;
-has int8 $!vsm_data15;
-has int8 $!vsm_data16;
-has int8 $!vsm_data17;
-has int8 $!vsm_data18;
-has int8 $!vsm_data19;
-has int8 $!vsm_data20;
-has int8 $!vsm_data21;
-has int8 $!vsm_data22;
-has int8 $!vsm_data23;
-has int8 $!vsm_data24;
-has int8 $!vsm_data25;
-has int8 $!vsm_data26;
-has int8 $!vsm_data27;
-has int8 $!vsm_data28;
-has int8 $!vsm_data29;
+# being, we just hack around it by embedding 8 64 members instead of a
+# 64 byte flattened array.
+has int64 $!vsm_data0;
+has int64 $!vsm_data1;
+has int64 $!vsm_data2;
+has int64 $!vsm_data3;
+has int64 $!vsm_data4;
+has int64 $!vsm_data5;
+has int64 $!vsm_data6;
+has int64 $!vsm_data7;
 
 # ZMQ_EXPORT int zmq_msg_init (zmq_msg_t *msg);
 my sub zmq_msg_init(Net::ZMQ::Message --> int32) is native('zmq',v5) { * }


### PR DESCRIPTION
This fixes the memory access faults and runs clean with valgrind