### PR TITLE
Tweak example

### DIFF
--- a/echo.pl
+++ b/echo.pl
@@ -11,7 +11,8 @@ loop {
     say "# Receiving...";
     my $msg = $sock.receive(0);
     last if not $msg;
-    say "`{$msg.data}'";
+    say $msg.data;
+    $msg.close;
 }
 
 # vim: ft=perl6


### PR DESCRIPTION
Most likely we want to `.close` messages and it is easier to print raw buffer to avoid `Cannot use a Buf as a string, but you called the Stringy method on it` exception.