### PR TITLE
General tweaks

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "Net::ZMQ",
-    "version" : "*",
+    "version" : "0.5",
     "author" : "Arne Skjærholt",
     "description" : "ZeroMQ bindings for Perl6",
     "provides" : {

--- a/META6.json
+++ b/META6.json
@@ -8,12 +8,12 @@
         "Net::ZMQ"            : "lib/Net/ZMQ.pm",
         "Net::ZMQ::Constants" : "lib/Net/ZMQ/Constants.pm",
         "Net::ZMQ::Context"   : "lib/Net/ZMQ/Context.pm",
-        "Net::ZMQ::Message"   : "lib/Net/ZMQ/Message.pm"
+        "Net::ZMQ::Message"   : "lib/Net/ZMQ/Message.pm",
         "Net::ZMQ::Poll"      : "lib/Net/ZMQ/Poll.pm",
         "Net::ZMQ::Pollitem"  : "lib/Net/ZMQ/Pollitem.pm",
         "Net::ZMQ::Proxy"      : "lib/Net/ZMQ/Proxy.pm6",
         "Net::ZMQ::Socket"    : "lib/Net/ZMQ/Socket.pm",
-        "Net::ZMQ::Util"      : "lib/Net/ZMQ/Util.pm",
+        "Net::ZMQ::Util"      : "lib/Net/ZMQ/Util.pm"
     },
     "depends" : [],
     "source-url" : "git://github.com/arnsholt/Net-ZMQ.git"

--- a/META6.json
+++ b/META6.json
@@ -6,13 +6,14 @@
     "description" : "ZeroMQ bindings for Perl6",
     "provides" : {
         "Net::ZMQ"            : "lib/Net/ZMQ.pm",
-        "Net::ZMQ::Pollitem"  : "lib/Net/ZMQ/Pollitem.pm",
-        "Net::ZMQ::Context"   : "lib/Net/ZMQ/Context.pm",
         "Net::ZMQ::Constants" : "lib/Net/ZMQ/Constants.pm",
+        "Net::ZMQ::Context"   : "lib/Net/ZMQ/Context.pm",
+        "Net::ZMQ::Message"   : "lib/Net/ZMQ/Message.pm"
+        "Net::ZMQ::Poll"      : "lib/Net/ZMQ/Poll.pm",
+        "Net::ZMQ::Pollitem"  : "lib/Net/ZMQ/Pollitem.pm",
+        "Net::ZMQ::Proxy"      : "lib/Net/ZMQ/Proxy.pm6",
         "Net::ZMQ::Socket"    : "lib/Net/ZMQ/Socket.pm",
         "Net::ZMQ::Util"      : "lib/Net/ZMQ/Util.pm",
-        "Net::ZMQ::Poll"      : "lib/Net/ZMQ/Poll.pm",
-        "Net::ZMQ::Message"   : "lib/Net/ZMQ/Message.pm"
     },
     "depends" : [],
     "source-url" : "git://github.com/arnsholt/Net-ZMQ.git"

--- a/lib/Net/ZMQ/Constants.pm
+++ b/lib/Net/ZMQ/Constants.pm
@@ -42,6 +42,7 @@ our constant ZMQ_RECOVERY_IVL_MSEC is export(:DEFAULT, :socket-options) = 20;
 our constant ZMQ_RECONNECT_IVL_MAX is export(:DEFAULT, :socket-options) = 21;
 our constant ZMQ_SNDHWM            is export(:DEFAULT, :socket-options) = 23;
 our constant ZMQ_RCVHWM            is export(:DEFAULT, :socket-options) = 24;
+our constant ZMQ_XPUB_MANUAL       is export(:DEFAULT, :socket-options) = 71;
 
 # Send/receive options:
 our constant ZMQ_NOBLOCK is export(:DEFAULT, :send-options) = 1;

--- a/lib/Net/ZMQ/Constants.pm
+++ b/lib/Net/ZMQ/Constants.pm
@@ -40,6 +40,8 @@ our constant ZMQ_RECONNECT_IVL     is export(:DEFAULT, :socket-options) = 18;
 our constant ZMQ_BACKLOG           is export(:DEFAULT, :socket-options) = 19;
 our constant ZMQ_RECOVERY_IVL_MSEC is export(:DEFAULT, :socket-options) = 20;
 our constant ZMQ_RECONNECT_IVL_MAX is export(:DEFAULT, :socket-options) = 21;
+our constant ZMQ_SNDHWM            is export(:DEFAULT, :socket-options) = 23;
+our constant ZMQ_RCVHWM            is export(:DEFAULT, :socket-options) = 24;
 
 # Send/receive options:
 our constant ZMQ_NOBLOCK is export(:DEFAULT, :send-options) = 1;

--- a/lib/Net/ZMQ/Proxy.pm6
+++ b/lib/Net/ZMQ/Proxy.pm6
@@ -1,0 +1,9 @@
+use NativeCall;
+
+# Message proxing
+# ZMQ_EXPORT int zmq_proxy (void *frontend, void *backend, void *capture);
+our sub zmq_proxy(Pointer[void], Pointer[void], Pointer[void] --> int32)
+    is native('zmq', v5) { * }
+# ZMQ_EXPORT int zmq_proxy_steerable (void *frontend, void *backend, void *capture, void *control);
+our sub zmq_proxy_steerable(Pointer[void], Pointer[void], Pointer[void], Pointer[void] --> int32)
+    is native('zmq', v5) { * }

--- a/lib/Net/ZMQ/Socket.pm
+++ b/lib/Net/ZMQ/Socket.pm
@@ -146,7 +146,7 @@ method receive(int $flags = 0) {
 }
 
 method getopt($opt) {
-    my size_t $optlen;
+    my $optlen = CArray[int32].new;
     my $ret;
 
     my CArray $val;
@@ -154,19 +154,19 @@ method getopt($opt) {
         when int {
             $val = CArray[int32].new;
             $val[0] = 0;
-            $optlen = 4;
+            $optlen[0] = 4;
             $ret = zmq_getsockopt_int(self, $opt, $val, $optlen);
         }
         when int32 {
             $val = CArray[int32].new;
             $val[0] = 0;
-            $optlen = 4;
+            $optlen[0] = 4;
             $ret = zmq_getsockopt_int32(self, $opt, $val, $optlen);
         }
         when int64 {
             $val = CArray[int64].new;
             $val[0] = 0;
-            $optlen = 8;
+            $optlen[0] = 8;
             $ret = zmq_getsockopt_int64(self, $opt, $val, $optlen);
         }
         # TODO: bytes

--- a/lib/Net/ZMQ/Socket.pm
+++ b/lib/Net/ZMQ/Socket.pm
@@ -87,7 +87,8 @@ my %opttypes = ZMQ_BACKLOG, int32,
                ZMQ_RCVHWM, int,
 
                ZMQ_IDENTITY, "bytes",
-               ZMQ_EVENTS, int32;
+               ZMQ_EVENTS, int32,
+               ZMQ_XPUB_MANUAL, int32;
 
 method new(Net::ZMQ::Context $context, int $type) {
     my $sock = zmq_socket($context, $type);

--- a/lib/Net/ZMQ/Socket.pm
+++ b/lib/Net/ZMQ/Socket.pm
@@ -81,6 +81,8 @@ my %opttypes = ZMQ_BACKLOG, int32,
                ZMQ_MCAST_LOOP, int64,
                ZMQ_SNDBUF, int64,
                ZMQ_RCVBUF, int64,
+               ZMQ_SNDHWM, int,
+               ZMQ_RCVHWM, int,
 
                ZMQ_IDENTITY, "bytes",
                ZMQ_EVENTS, int32;
@@ -144,7 +146,7 @@ method receive(int $flags = 0) {
 }
 
 method getopt($opt) {
-    my CArray $optlen = CArray[int].new;
+    my size_t $optlen;
     my $ret;
 
     my CArray $val;
@@ -152,19 +154,19 @@ method getopt($opt) {
         when int {
             $val = CArray[int32].new;
             $val[0] = 0;
-            $optlen[0] = 4;
+            $optlen = 4;
             $ret = zmq_getsockopt_int(self, $opt, $val, $optlen);
         }
         when int32 {
             $val = CArray[int32].new;
             $val[0] = 0;
-            $optlen[0] = 4;
+            $optlen = 4;
             $ret = zmq_getsockopt_int32(self, $opt, $val, $optlen);
         }
         when int64 {
             $val = CArray[int64].new;
             $val[0] = 0;
-            $optlen[0] = 8;
+            $optlen = 8;
             $ret = zmq_getsockopt_int64(self, $opt, $val, $optlen);
         }
         # TODO: bytes
@@ -183,7 +185,7 @@ method getopt($opt) {
 }
 
 method setopt($opt, $value) {
-    my CArray $optlen = CArray[int32].new;
+    my size_t $optlen;
     my $ret;
 
     my CArray $val;
@@ -191,19 +193,19 @@ method setopt($opt, $value) {
         when int {
             $val = CArray[int32].new;
             $val[0] = $value;
-            $optlen[0] = 4;
+            $optlen = 4;
             $ret = zmq_setsockopt_int(self, $opt, $val, $optlen);
         }
         when int32 {
             $val = CArray[int32].new;
             $val[0] = $value;
-            $optlen[0] = 4;
+            $optlen = 4;
             $ret = zmq_setsockopt_int32(self, $opt, $val, $optlen);
         }
         when int64 {
             $val = CArray[int64].new;
             $val[0] = $value;
-            $optlen[0] = 8;
+            $optlen = 8;
             $ret = zmq_setsockopt_int64(self, $opt, $val, $optlen);
         }
         # TODO: bytes

--- a/lib/Net/ZMQ/Socket.pm
+++ b/lib/Net/ZMQ/Socket.pm
@@ -104,6 +104,11 @@ method connect(Str $address) {
     zmq_die() if $ret != 0;
 }
 
+method close() {
+    my $ret = zmq_close(self);
+    zmq_die() if $ret != 0;
+}
+
 # TODO: There's probably a more Perlish way to handle the flags.
 #multi method send(Str $message, $flags = 0) {
 #    return self.send($message.encode("utf8"), $flags);

--- a/t/00-basic.t
+++ b/t/00-basic.t
@@ -39,6 +39,6 @@ $msg.close;
 
 $alice.close;
 $bob.close;
-# $ctx.terminate;
+$ctx.terminate;
 
 # vim: ft=perl6

--- a/t/00-basic.t
+++ b/t/00-basic.t
@@ -39,5 +39,6 @@ $msg.close;
 
 $alice.close;
 $bob.close;
+# $ctx.terminate;
 
 # vim: ft=perl6

--- a/t/00-basic.t
+++ b/t/00-basic.t
@@ -37,4 +37,7 @@ ok $msg =  $bob.receive(0), "get the second part of the message";
 is $msg.data-str(), 'barf', 'receiving second part of two-parter';
 $msg.close;
 
+$alice.close;
+$bob.close;
+
 # vim: ft=perl6

--- a/t/05-binary.t
+++ b/t/05-binary.t
@@ -32,5 +32,6 @@ ok $bob.receive(0).data() eqv $buf, 'sending and receiving simple binary message
 
 $alice.close;
 $bob.close;
+$ctx.terminate;
 
 # vim: ft=perl6

--- a/t/05-binary.t
+++ b/t/05-binary.t
@@ -8,12 +8,18 @@ use Net::ZMQ::Constants;
 plan 6;
 
 my Net::ZMQ::Context $ctx .= new();
+
 pass 'creating context';
 
 my Net::ZMQ::Socket $alice .= new($ctx, ZMQ_PAIR); #Net::ZMQ::Constants::ZMQ_PAIR);
 pass 'creating socket - imported constant';
 my Net::ZMQ::Socket $bob .= new($ctx, Net::ZMQ::Constants::ZMQ_PAIR); #Net::ZMQ::Constants::ZMQ_PAIR);
 pass 'creating socket - namespaced constant';
+
+$alice.setopt(ZMQ_SNDHWM, 10);
+$alice.setopt(ZMQ_RCVHWM, 10);
+$bob.setopt(ZMQ_SNDHWM, 10);
+$bob.setopt(ZMQ_RCVHWM, 10);
 
 $alice.bind('inproc://alice');
 pass 'binding to inproc address';

--- a/t/05-binary.t
+++ b/t/05-binary.t
@@ -24,4 +24,7 @@ my $buf = buf8.new(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
 $alice.send($buf, 0);
 ok $bob.receive(0).data() eqv $buf, 'sending and receiving simple binary message';
 
+$alice.close;
+$bob.close;
+
 # vim: ft=perl6


### PR DESCRIPTION
Closes https://github.com/arnsholt/Net-ZMQ/issues/15
Semi-closes https://github.com/arnsholt/Net-ZMQ/issues/14 (needs additional investigation, because someone may really use ZMQ_HWM, which was deprecated since 3.2(see http://zeromq.org/docs:3-1-upgrade). Ideally, we need to manually specify supported ZMQ version to actual(4.2), bump version and them remove all deprecated stuff & add all new stuff.
Controversial change: version setting. I don't know why the version is set to `*` now, but otherwise API breaking will be a hell painful.

Fixes setopt a bit too.

Needs a review because I am a teapot and not sure what I'm doing.